### PR TITLE
feat/async-logging: created async logging methods BREAKING CHANGES

### DIFF
--- a/WSharp/Logging/Loggers/ILogger.cs
+++ b/WSharp/Logging/Loggers/ILogger.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace WSharp.Logging.Loggers
 {
@@ -24,54 +22,18 @@ namespace WSharp.Logging.Loggers
         IBufferLogEntry Buffer { get; }
 
         /// <summary>Logs the given entry if it passes the logfilter.</summary>
-        /// <param name="logEntry">Log entry to log.</param>
-        void Log(IBufferLogEntry logEntry);
-
-        /// <summary>Logs the given entry if it passes the logfilter.</summary>
         /// <param name="logEntry">Log entry to log.``</param>
         void Log(ILogEntry logEntry);
 
         /// <summary>Logs the <see cref="Buffer"/>.</summary>
         void LogBuffer();
 
-        /// <summary>
-        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
-        /// </summary>
-        /// <param name="source">The source that logs.</param>
-        /// <param name="payload">The payload to log.</param>
-        /// <param name="eventType">Type of the event that causes the log.</param>
-        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
-        void Log(string source, object o, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null);
+        /// <summary>Logs the given entry if it passes the logfilter.</summary>
+        /// <param name="logEntry">Log entry to log.``</param>
+        Task LogAsync(ILogEntry logEntry);
 
-        /// <summary>
-        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
-        /// </summary>
-        /// <param name="source">The source that logs.</param>
-        /// <param name="payload">The payload to log.</param>
-        /// <param name="eventType">Type of the event that causes the log.</param>
-        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
-        void Log(string source, object[] payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null);
-
-        /// <summary>
-        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
-        /// </summary>
-        /// <param name="eventType">Type of the event that causes the log.</param>
-        /// <param name="source">The source that logs.</param>
-        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
-        /// <param name="title">Title of the log.</param>
-        /// <param name="payload">The payload to log.</param>
-        /// <param name="traceOptions">Tracing options that should be added to the log.</param>
-        /// <param name="indentLevel">Level of indent at which the log should be logged.</param>
-        /// <param name="indentSize">Size of the indents.</param>
-        void Log(
-            TraceEventType eventType = TraceEventType.Verbose,
-            string source = null,
-            [CallerMemberName] string tag = null,
-            string title = null,
-            IList<object> payload = null,
-            TraceOptions traceOptions = LogEntry.DefaultOptions,
-            ushort indentLevel = 0,
-            ushort indentSize = 0);
+        /// <summary>Logs the <see cref="Buffer"/>.</summary>
+        Task LogBufferAsync();
 
         /// <summary>Releases all resources.</summary>
         /// <param name="isDisposing">

--- a/WSharp/Logging/Loggers/LogDispatcher.cs
+++ b/WSharp/Logging/Loggers/LogDispatcher.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace WSharp.Logging.Loggers
 {
@@ -40,6 +42,9 @@ namespace WSharp.Logging.Loggers
             foreach (var l in this)
                 l.Log(logEntry);
         }
+
+        protected override Task InternalLogAsync(ILogEntry logEntry)
+            => Task.WhenAll(this.Select(x => x.LogAsync(logEntry)));
 
         /// <summary>Adds a logger to the dispatchers collection.</summary>
         /// <param name="item">Logger to add to the dispatcher</param>

--- a/WSharp/Logging/Loggers/LoggerExtensions.cs
+++ b/WSharp/Logging/Loggers/LoggerExtensions.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace WSharp.Logging.Loggers
+{
+    public static class LoggerExtensions
+    {
+        /// <summary>Logs the given entry if it passes the logfilter.</summary>
+        /// <param name="logEntry">Log entry to log.</param>
+        public static void Log(this ILogger logger, IBufferLogEntry logEntry) 
+            => logger.Log(new LogEntry(logEntry));
+
+        /// <summary>
+        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
+        /// </summary>
+        /// <param name="source">The source that logs.</param>
+        /// <param name="payload">The payload to log.</param>
+        /// <param name="eventType">Type of the event that causes the log.</param>
+        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
+        public static void Log(this ILogger logger, string source, object payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
+            => logger.Log(new LogEntry(source, tag, payload: payload == null ? null : new[] { payload }, eventType: eventType));
+
+        /// <summary>
+        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
+        /// </summary>
+        /// <param name="source">The source that logs.</param>
+        /// <param name="payload">The payload to log.</param>
+        /// <param name="eventType">Type of the event that causes the log.</param>
+        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
+        public static void Log(this ILogger logger, string source, object[] payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
+            => logger.Log(new LogEntry(source, tag, payload: payload, eventType: eventType));
+
+        /// <summary>
+        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
+        /// </summary>
+        /// <param name="eventType">Type of the event that causes the log.</param>
+        /// <param name="source">The source that logs.</param>
+        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
+        /// <param name="title">Title of the log</param>
+        /// <param name="payload">The payload to log.</param>
+        /// <param name="traceOptions">Tracing options that should be added to the log</param>
+        /// <param name="indentLevel">Level of indent at which the log should be logged.</param>
+        /// <param name="indentSize">Size of the indents.</param>
+        public static void Log(
+            this ILogger logger,
+            TraceEventType eventType = TraceEventType.Verbose,
+            string source = null,
+            [CallerMemberName] string tag = null,
+            string title = null,
+            IList<object> payload = null,
+            TraceOptions traceOptions = TraceOptions.DateTime,
+            ushort indentLevel = 0,
+            ushort indentSize = 0)
+            => logger.Log(new LogEntry(
+               source,
+               tag,
+               eventType,
+               title,
+               payload == null ? null : new ReadOnlyCollection<object>(payload),
+               traceOptions,
+               indentLevel,
+               indentSize));
+
+        /// <summary>Logs the given entry if it passes the logfilter.</summary>
+        /// <param name="logEntry">Log entry to log.</param>
+        public static Task LogAsync(this ILogger logger, IBufferLogEntry logEntry)
+            => logger.LogAsync(new LogEntry(logEntry));
+
+        /// <summary>
+        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
+        /// </summary>
+        /// <param name="source">The source that logs.</param>
+        /// <param name="payload">The payload to log.</param>
+        /// <param name="eventType">Type of the event that causes the log.</param>
+        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
+        public static Task LogAsync(this ILogger logger, string source, object payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
+            => logger.LogAsync(new LogEntry(source, tag, payload: payload == null ? null : new[] { payload }, eventType: eventType));
+
+        /// <summary>
+        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
+        /// </summary>
+        /// <param name="source">The source that logs.</param>
+        /// <param name="payload">The payload to log.</param>
+        /// <param name="eventType">Type of the event that causes the log.</param>
+        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
+        public static Task LogAsync(this ILogger logger, string source, object[] payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
+            => logger.LogAsync(new LogEntry(source, tag, payload: payload, eventType: eventType));
+
+        /// <summary>
+        ///     Builds a log entry from the given parameters and logs it if it passes the filter.
+        /// </summary>
+        /// <param name="eventType">Type of the event that causes the log.</param>
+        /// <param name="source">The source that logs.</param>
+        /// <param name="tag">A tag to identify the log (by default the name of the caller).</param>
+        /// <param name="title">Title of the log</param>
+        /// <param name="payload">The payload to log.</param>
+        /// <param name="traceOptions">Tracing options that should be added to the log</param>
+        /// <param name="indentLevel">Level of indent at which the log should be logged.</param>
+        /// <param name="indentSize">Size of the indents.</param>
+        public static Task LogAsync(
+            this ILogger logger,
+            TraceEventType eventType = TraceEventType.Verbose,
+            string source = null,
+            [CallerMemberName] string tag = null,
+            string title = null,
+            IList<object> payload = null,
+            TraceOptions traceOptions = TraceOptions.DateTime,
+            ushort indentLevel = 0,
+            ushort indentSize = 0)
+            => logger.LogAsync(new LogEntry(
+               source,
+               tag,
+               eventType,
+               title,
+               payload == null ? null : new ReadOnlyCollection<object>(payload),
+               traceOptions,
+               indentLevel,
+               indentSize));
+    }
+}

--- a/WSharp/Logging/Loggers/MemoryLogger.cs
+++ b/WSharp/Logging/Loggers/MemoryLogger.cs
@@ -5,16 +5,13 @@ namespace WSharp.Logging.Loggers
     /// <summary>Logger that logs to memory (a collection of logs)</summary>
     public class MemoryLogger : ALogger, IMemoryLogger
     {
-        #region FIELDS
-
-        private readonly ObservableCollection<ILogEntry> _logs = new ObservableCollection<ILogEntry>();
-
-        #endregion FIELDS
-
         #region PROPERTIES
 
+        /// <summary>Modifyable collection of logs that have been logged.</summary>
+        protected ObservableCollection<ILogEntry> InternalLogs { get; } = new ObservableCollection<ILogEntry>();
+
         /// <summary>Collection of logs that have been logged.</summary>
-        public ReadOnlyObservableCollection<ILogEntry> Logs => new ReadOnlyObservableCollection<ILogEntry>(_logs);
+        public ReadOnlyObservableCollection<ILogEntry> Logs => new ReadOnlyObservableCollection<ILogEntry>(InternalLogs);
 
         #endregion PROPERTIES
 
@@ -27,12 +24,12 @@ namespace WSharp.Logging.Loggers
             if (isDisposing)
                 return;
 
-            _logs.Clear();
+            InternalLogs.Clear();
         }
 
         /// <summary>Method that actually logs the log entry.</summary>
         /// <param name="logEntry">Entry to log.</param>
-        protected override void InternalLog(ILogEntry logEntry) => _logs.Add(logEntry);
+        protected override void InternalLog(ILogEntry logEntry) => InternalLogs.Add(logEntry);
 
         #endregion METHODS
     }

--- a/WSharp/Logging/Loggers/TextWriterLogger.cs
+++ b/WSharp/Logging/Loggers/TextWriterLogger.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.Versioning;
+using System.Threading.Tasks;
 
 namespace WSharp.Logging.Loggers
 {
@@ -114,6 +115,19 @@ namespace WSharp.Logging.Loggers
             {
                 _writer.Write(logEntry);
                 _writer.Flush();
+            }
+            catch (ObjectDisposedException) { }
+        }
+
+        protected override async Task InternalLogAsync(ILogEntry logEntry)
+        {
+            if (!EnsureWriter())
+                return;
+
+            try
+            {
+                await _writer.WriteAsync(logEntry.ToString());
+                await _writer.FlushAsync();
             }
             catch (ObjectDisposedException) { }
         }


### PR DESCRIPTION
## Added log async log methods to `ILogger`:
Added som async methods to the `ILogger` and implemented them in the existing logger implementations
```        
Task LogAsync(ILogEntry logEntry);
Task LogBufferAsync();
```
## Moved log methods from `ILogger` to extension methods:
```
void Log(IBufferLogEntry logEntry) 
void Log(string source, object payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
void Log(string source, object[] payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
void Log(
    this ILogger logger,
    TraceEventType eventType = TraceEventType.Verbose,
    string source = null,
    [CallerMemberName] string tag = null,
    string title = null,
    IList<object> payload = null,
    TraceOptions traceOptions = TraceOptions.DateTime,
    ushort indentLevel = 0,
    ushort indentSize = 0)
```

## Added extensions methods for `ILogger`
```
Task LogAsync(this ILogger logger, IBufferLogEntry logEntry)
Task LogAsync(this ILogger logger, string source, object payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
Task LogAsync(this ILogger logger, string source, object[] payload, TraceEventType eventType = TraceEventType.Verbose, [CallerMemberName] string tag = null)
Task LogAsync(
    this ILogger logger,
    TraceEventType eventType = TraceEventType.Verbose,
    string source = null,
    [CallerMemberName] string tag = null,
    string title = null,
    IList<object> payload = null,
    TraceOptions traceOptions = TraceOptions.DateTime,
    ushort indentLevel = 0,
    ushort indentSize = 0)
```